### PR TITLE
Add 'test' directory as a spec directory

### DIFF
--- a/lib/path_finder.coffee
+++ b/lib/path_finder.coffee
@@ -13,7 +13,7 @@ class PathFinder
     helper: ['app/helpers', 'submodules/app/helpers']
     mailer: ['app/mailers', 'submodules/app/mailers']
     db: ['db', 'submodules/db']
-    spec: ['spec']
+    spec: ['spec', 'test']
     lib: ['lib', 'submodules/lib']
     log: ['log']
     asset: ['app/assets']


### PR DESCRIPTION
The test directory is used by minitest which is default in ruby / ruby on rails.

Thanks for making this atom package :+1: 
